### PR TITLE
Update caido download links

### DIFF
--- a/roles/redteam-web/tasks/caido.yaml
+++ b/roles/redteam-web/tasks/caido.yaml
@@ -12,7 +12,7 @@
 
 - name: Download Linux artifact
   ansible.builtin.get_url:
-    url:  "https://storage.googleapis.com/caido-releases/{{ caido_release.json.name }}/caido-desktop-{{ caido_release.json.name }}-linux-x86_64.deb"
+    url:  "https://caido.download/releases/{{ caido_release.json.name }}/caido-desktop-{{ caido_release.json.name }}-linux-x86_64.deb"
     dest: "/tmp/caido-desktop-{{ caido_release.json.name }}-linux-x86_64.deb"
 
 - name: "install caido"


### PR DESCRIPTION
Hi! Creator of Caido here.
We are moving away from GCP and onto our own download domain.
Older links won't work within the next 30 days.
Documentation: https://docs.caido.io/concepts/internals/download.html